### PR TITLE
Add support for logging to up2date

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ register | Register system with RHN | Boolean | true
 retries | Network retries for package commands | Fixnum | 1
 ssl | Enable SSL | Boolean | true
 username | RHN username for hosted RHN operations | String | rhnuser
+write_log | Log to /var/log/up2date which packages has been added and removed | Fixnum | 0
 
 ### Actions Attributes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,6 +6,7 @@ default['rhn']['register'] = true
 default['rhn']['retries'] = 1
 default['rhn']['ssl'] = true
 default['rhn']['username'] = 'rhnuser'
+default['rhn']['write_log'] = 0
 
 default['rhn']['actions']['disabled'] = []
 default['rhn']['actions']['enabled'] = []

--- a/templates/default/up2date.erb
+++ b/templates/default/up2date.erb
@@ -22,7 +22,7 @@ enableProxy[comment]=Use a HTTP Proxy
 enableProxy=<%= node['rhn']['proxy']['url'] ? '1' : '0' %>
 
 writeChangesToLog[comment]=Log to /var/log/up2date which packages has been added and removed
-writeChangesToLog=0
+writeChangesToLog=<%= node['rhn']['write_log'] %>
 
 serverURL[comment]=Remote server URL (use FQDN)
 serverURL=https://<%= node['rhn']['hostname'] %>/XMLRPC


### PR DESCRIPTION
Add support for logging changes to /var/log/up2date.  Change is backwards compatible with old default.