### PR TITLE
Dynamic values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 0.2.0
+# bleh
 
 * Enhancement: Add username/password support for hosted RHN
 * Enhancement: Add proxy support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 ## 0.2.0
-# bleh
 
 * Enhancement: Add username/password support for hosted RHN
 * Enhancement: Add proxy support

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -9,7 +9,7 @@ module Helpers
         when Array
           cli_line += value.map { |a| " --#{arg} " + a }.join
         when Fixnum, Integer, String
-          cli_line += " --#{arg} #{value}"
+          cli_line += " --#{arg} '#{value}'"
         when TrueClass
           cli_line += " --#{arg}"
         end

--- a/providers/system.rb
+++ b/providers/system.rb
@@ -43,7 +43,13 @@ EOM
 end
 
 def registered?
-  @current_resource.system_id
+  registered = false
+  cmd = Mixlib::ShellOut.new('/usr/sbin/rhn-profile-sync')
+  begin cmd.run_command
+    rescue Errno::ENOENT
+  end
+  registered = true unless cmd.error?
+  registered
 end
 
 def register

--- a/providers/system.rb
+++ b/providers/system.rb
@@ -30,7 +30,7 @@ end
 def execute_cmd(cmd, timeout = new_resource.cmd_timeout)
   Chef::Log.debug('Executing: ' + cmd)
   begin
-    shell_out(cmd, :timeout => timeout)
+    shell_out!(cmd, :timeout => timeout)
   rescue Mixlib::ShellOut::CommandTimeout
     raise CommandTimeout, <<-EOM
 

--- a/providers/system_action.rb
+++ b/providers/system_action.rb
@@ -48,5 +48,5 @@ end
 
 def execute_cmd(cmd)
   Chef::Log.debug('Executing: ' + cmd)
-  shell_out(cmd)
+  shell_out!(cmd)
 end

--- a/providers/system_action.rb
+++ b/providers/system_action.rb
@@ -7,7 +7,7 @@ def load_current_resource
   if new_resource.action_name == 'run'
     @current_resource.enabled(true) if ::File.exist?('/etc/sysconfig/rhn/allowed-actions/script/run')
   else
-    @current_resource.enabled(true) if ::File.exist?("/etc/sysconfig/rhn/allowed-actions/configfiles/#{rhn_action}")
+    @current_resource.enabled(true) if ::File.exist?("/etc/sysconfig/rhn/allowed-actions/configfiles/#{new_resource.action_name}")
   end
   @current_resource
 end

--- a/recipes/register.rb
+++ b/recipes/register.rb
@@ -1,1 +1,4 @@
-rhn_system node['hostname']
+rhn_system node['hostname'] do
+  hostname node['rhn']['hostname']
+  activation_keys node['rhn']['activation_keys']
+end


### PR DESCRIPTION
When setting values of node['rhn'] at execution time instead of compile time, such as determining rhn hostname, generating activation keys, etc the providers would fail to reflect those changes and proceed with the compile time defaults..  This should fix some, not all, of those issues.

Found several cases where the current method of checking for the systemid in a file would incorrectly reflect the actual registration status of the server.  Switched to calling out to satellite and trapping the failure/success to determine it the host is registered.

Additionally by not using shell_out! it was possible for the shell commands to fail silently and then the recipe would die later in the run, obfuscating the real issue.  Instead of writing an entire exit code trapping mechanism, simply changing from shell_out -> shell_out! provents the code from failing silently.