### PR TITLE
Add ignore_failure attribute for org_ca_cert

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,6 +14,7 @@ default['rhn']['actions']['enabled'] = []
 default['rhn']['org_ca_cert']['action'] = 'install'
 default['rhn']['org_ca_cert']['name'] = 'RHNS-CA-CERT'
 default['rhn']['org_ca_cert']['url'] = "https://#{node['rhn']['hostname']}/pub/#{node['rhn']['org_ca_cert']['name']}"
+default['rhn']['org_ca_cert']['ignore_failure'] = false
 
 default['rhn']['org_gpg_key']['name'] = 'ORG-GPG-KEY'
 default['rhn']['org_gpg_key']['pub'] = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'bflad417@gmail.com'
 license 'Apache 2.0'
 description 'Registers node with RHN'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.3.1'
+version '0.3.2'
 recipe 'rhn', 'RHN client configuration and system registration'
 recipe 'rhn::actions', 'Configures RHN system actions on client'
 recipe 'rhn::org_ca_cert', 'Installs organization CA certificate'

--- a/recipes/org_ca_cert.rb
+++ b/recipes/org_ca_cert.rb
@@ -9,6 +9,7 @@ if node['rhn']['org_ca_cert']['url'].match(/\.rpm$/)
     source node['rhn']['org_ca_cert']['url']
     if node['rhn']['org_ca_cert']['action'] == 'upgrade'
       action :create
+      ignore_failure node['rhn']['org_ca_cert']['ignore_failure']
     else
       action :create_if_missing
     end
@@ -26,6 +27,7 @@ else
     source node['rhn']['org_ca_cert']['url']
     if node['rhn']['org_ca_cert']['action'] == 'upgrade'
       action :create
+      ignore_failure node['rhn']['org_ca_cert']['ignore_failure']
     else
       action :create_if_missing
     end


### PR DESCRIPTION
We use org_ca_cert in upgrade mode and we have a need to ignore remote_file failures (as our Satellite server is occasionally unavailable). This PR adds an ignore_failure attribute that defaults to false so it doesn't change the default cookbook behavior but will allow us to override it as needed.