### PR TITLE
Add `rhn_channel` provider for enabling/disabling Satellite channels on a node

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,13 +189,26 @@ Enable all actions on node:
 rhn_system_action 'all'
 ```
 
-#### rhn_channel action :join
+### rhn_channel
+Below are the available actions for the LWRP, default being `enable`.
+
+#### rhn_channel action :enable
 The name attribute is the channel name. Using this LWRP will require credentials similar to the rhn_system LWRP. Enable is the default action. You can disable a channel by explicitly declaring :disable as the resource action.
 
 Enable 'foo' channel on node:
 ```
 rhn_channel 'foo' do
   action :enable
+  username my_encrypted_bag['user']
+  password my_encrypted_bag['pass']
+end
+```
+
+#### rhn_channel action :disable
+Disable 'foo' channel on node:
+```
+rhn_channel 'foo' do
+  action :disable
   username my_encrypted_bag['user']
   password my_encrypted_bag['pass']
 end

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ interval | Sync interval in minutes (must be above 60) | Fixnum | 240
 
 * system: Register node with RHN
 * system_action: Enable/disable RHN system action on node
+* rhn_channel: Enable/disable channels on node
 
 ### rhn_system
 
@@ -186,6 +187,18 @@ Enable all actions on node:
 
 ```
 rhn_system_action 'all'
+```
+
+#### rhn_channel action :join
+The name attribute is the channel name. Using this LWRP will require credentials similar to the rhn_system LWRP. Enable is the default action. You can disable a channel by explicitly declaring :disable as the resource action.
+
+Enable 'foo' channel on node:
+```
+rhn_channel 'foo' do
+  action :enable
+  username my_encrypted_bag['user']
+  password my_encrypted_bag['pass']
+end
 ```
 
 ## Recipes

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,6 +7,7 @@ default['rhn']['retries'] = 1
 default['rhn']['ssl'] = true
 default['rhn']['username'] = 'rhnuser'
 default['rhn']['profilename'] = node['hostname'] || node['fqdn']
+default['rhn']['channels'] = Mixlib::ShellOut.new('rhn-channel -l').run_command.stdout.split
 
 default['rhn']['actions']['disabled'] = []
 default['rhn']['actions']['enabled'] = []

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'bflad417@gmail.com'
 license 'Apache 2.0'
 description 'Registers node with RHN'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.3.3'
+version '0.3.4'
 recipe 'rhn', 'RHN client configuration and system registration'
 recipe 'rhn::actions', 'Configures RHN system actions on client'
 recipe 'rhn::org_ca_cert', 'Installs organization CA certificate'

--- a/providers/rhn_channel.rb
+++ b/providers/rhn_channel.rb
@@ -1,0 +1,33 @@
+use_inline_resources
+
+action :enable do
+  execute "#{new_resource.name} :join #{new_resource.channel_name}" do
+    sensitive true
+    command rhn_cmd('-a')
+    not_if { channel_enabled? }
+  end
+end
+
+action :disable do
+  execute "#{new_resource.name} :unjoin #{new_resource.channel_name}" do
+    sensitive true
+    command rhn_cmd('-r')
+    only_if { channel_enabled? }
+  end
+end
+
+def channel_enabled?
+  node['rhn']['channels'].include? new_resource.channel_name.to_s
+rescue
+  false
+end
+
+# rubocop:disable Metrics/AbcSize
+def rhn_cmd(args)
+  options = {}
+  options['-u'] = new_resource.username unless new_resource.username.nil?
+  options['-p'] = new_resource.password unless new_resource.password.nil?
+  options['-c'] = new_resource.channel_name
+  ['rhn-channel', args, options.map { |k, v| "#{k} '#{v}'" }].flatten.join(' ')
+end
+# rubocop:enable Metrics/AbcSize

--- a/resources/rhn_channel.rb
+++ b/resources/rhn_channel.rb
@@ -1,0 +1,7 @@
+provides :rhn_channel
+actions :enable, :disable
+default_action :enable
+
+attribute :channel_name, kind_of: String, name_attribute: true
+attribute :username, kind_of: [String, NilClass], default: nil
+attribute :password, kind_of: [String, NilClass], default: nil


### PR DESCRIPTION
This provider should, with appropriately privileged credentials, join or unjoin a node from arbitrary satellite/RHN channels.